### PR TITLE
IJava uptade to match latest kernel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    shade group: 'io.github.spencerpark', name: 'jupyter-jvm-basekernel', version: '1.1.1-SNAPSHOT'
+    shade group: 'io.github.spencerpark', name: 'jupyter-jvm-basekernel', version: '2.0.0-SNAPSHOT'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/io/github/spencerpark/ijava/JavaKernel.java
+++ b/src/main/java/io/github/spencerpark/ijava/JavaKernel.java
@@ -34,7 +34,7 @@ import io.github.spencerpark.jupyter.kernel.util.CharPredicate;
 import io.github.spencerpark.jupyter.kernel.util.StringStyler;
 import io.github.spencerpark.jupyter.kernel.util.TextColor;
 import io.github.spencerpark.jupyter.messages.Header;
-import io.github.spencerpark.jupyter.messages.MIMEBundle;
+import io.github.spencerpark.jupyter.messages.DisplayData;
 import jdk.jshell.*;
 
 import java.util.ArrayList;
@@ -235,7 +235,7 @@ public class JavaKernel extends BaseKernel {
     }
 
     @Override
-    public MIMEBundle eval(String expr) throws Exception {
+    public DisplayData eval(String expr) throws Exception {
         expr = this.magicParser.transformCellMagic(expr, this::transformCellMagic);
         expr = this.magicParser.transformLineMagics(expr, this::transformLineMagic);
 
@@ -243,7 +243,7 @@ public class JavaKernel extends BaseKernel {
     }
 
     @Override
-    public MIMEBundle inspect(String code, int at, boolean extraDetail) {
+    public DisplayData inspect(String code, int at, boolean extraDetail) {
         // Move the code position to the end of the identifier to make the inspection work at any
         // point in the identifier. i.e "System.o|ut" or "System.out|" will return the same result.
         while (at + 1 < code.length() && IDENTIFIER_CHAR.test(code.charAt(at + 1))) at++;
@@ -259,7 +259,7 @@ public class JavaKernel extends BaseKernel {
             return null;
         }
 
-        MIMEBundle fmtDocs = new MIMEBundle(
+        DisplayData fmtDocs = new DisplayData(
                 documentations.stream()
                         .map(doc -> {
                             String formatted = doc.signature();

--- a/src/main/java/io/github/spencerpark/ijava/execution/CodeEvaluator.java
+++ b/src/main/java/io/github/spencerpark/ijava/execution/CodeEvaluator.java
@@ -23,7 +23,7 @@
  */
 package io.github.spencerpark.ijava.execution;
 
-import io.github.spencerpark.jupyter.messages.MIMEBundle;
+import io.github.spencerpark.jupyter.messages.DisplayData;
 import jdk.jshell.JShell;
 import jdk.jshell.JShellException;
 import jdk.jshell.SnippetEvent;
@@ -92,7 +92,7 @@ public class CodeEvaluator {
         return result;
     }
 
-    public MIMEBundle eval(String code) throws Exception {
+    public DisplayData eval(String code) throws Exception {
         // The init() method runs some code in the shell to initialize the environment. As such
         // it is deferred until the first user requested evaluation to cleanly return errors when
         // they happen.
@@ -110,7 +110,7 @@ public class CodeEvaluator {
         if (info.completeness() != SourceCodeAnalysis.Completeness.EMPTY)
             throw new IncompleteSourceException(info.remaining().trim());
 
-        return lastEvalResult == null || lastEvalResult.isEmpty() ? null : new MIMEBundle(lastEvalResult);
+        return lastEvalResult == null || lastEvalResult.isEmpty() ? null : new DisplayData(lastEvalResult);
     }
 
     public void interrupt() {


### PR DESCRIPTION
Firstly, Thank you for this awesome project.
Second, I was having a hard time installing it on Linux and compiling it. I've noticed that you have updated the kernel but the code on the notebook references a `MIMEBundle` that has been changed to `DisplayData`. So this PR address just that.
Also, I've run into a lot of problems with sun certificates running your scripts with open-jdk-9-headless, just for your information, I've had to use the Official Oracle Java-9.0.1 and update Gradle to 4.2.1 to make it work.
I also have added the Libs/ folder to make it easier for new users to just download this project compile and make it work.
Thanks again,