### PR TITLE
Update Ivy version to 2.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 dependencies {
     shade group: 'io.github.spencerpark', name: 'jupyter-jvm-basekernel', version: '2.3.0'
 
-    shade group: 'org.apache.ivy', name: 'ivy', version: '2.5.0-rc1'
+    shade group: 'org.apache.ivy', name: 'ivy', version: '2.5.2'
     //shade group: 'org.apache.maven', name: 'maven-settings-builder', version: '3.6.0'
     shade group: 'org.apache.maven', name: 'maven-model-builder', version: '3.6.0'
 


### PR DESCRIPTION
This PR should solve SpencerPark/IJava#63 issue.

The underlying problem is that current Ivy version couldn't process correctly `test-jar` dependencies.